### PR TITLE
fix(playback): Remove redundant pause/play call on playerplay

### DIFF
--- a/src/js/Dash.js
+++ b/src/js/Dash.js
@@ -170,11 +170,6 @@ class Dash extends Meister.MediaPlugin {
                 this.dash.initialize(this.player.mediaElement, item.src, false);
             }
 
-            this.one('playerPlay', () => {
-                this.dash.pause();
-                this.dash.play();
-            });
-
             // Handle autplay
             this.one('requestPlay', () => {
                 this.dash.play();


### PR DESCRIPTION
Originally this was implemented to kickstart the manifest fetching
process in livestreams, which would sometimes not start correctly by
itself. Given that this was over 2 years and several dash.js versions
ago it is no surprise that it no longer seems to be required.