### PR TITLE
fix(live): Remove arbitrary 30 second buffer when seeking to live

### DIFF
--- a/src/js/Dash.js
+++ b/src/js/Dash.js
@@ -388,9 +388,8 @@ class Dash extends Meister.MediaPlugin {
 
     goLive() {
         const duration = this.dash.duration();
-        const liveTime = duration - 30;
 
-        this.player.currentTime = this.dash.getDVRSeekOffset(liveTime);
+        this.player.currentTime = this.dash.getDVRSeekOffset(duration - 1);
     }
 }
 


### PR DESCRIPTION
I figure it's probably better to let the player handle any buffering
issues itself.